### PR TITLE
feat: introduces version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,20 @@ upload-release:
 
 SRCS=$(shell find ./pkg -name "*.go") $(shell find ./cmd -name "*.go")
 
+# Pass in build-time variables
+LDFLAGS=-ldflags "-X main.KubeSquashVersion=$(VERSION) -X github.com/solo-io/kubesquash/pkg/cmd.ImageVersion=$(VERSION) -X github.com/solo-io/kubesquash/pkg/cmd.ImageRepo=$(DOCKER_REPO)"
+
 target:
 	[ -d $@ ] || mkdir -p $@
 
 target/kubesquash: target $(SRCS)
-	go build -ldflags "-X github.com/solo-io/kubesquash/pkg/cmd.ImageVersion=$(VERSION) -X github.com/solo-io/kubesquash/pkg/cmd.ImageRepo=$(DOCKER_REPO)" -o $@ ./cmd/kubesquash
+	go build  ${LDFLAGS} -o $@ ./cmd/kubesquash
 
 target/kubesquash-osx: target $(SRCS)
-	GOOS=darwin go build -ldflags "-X github.com/solo-io/kubesquash/pkg/cmd.ImageVersion=$(VERSION) -X github.com/solo-io/kubesquash/pkg/cmd.ImageRepo=$(DOCKER_REPO)" -o $@ ./cmd/kubesquash
+	GOOS=darwin go build ${LDFLAGS} -o $@ ./cmd/kubesquash
 
 target/kubesquash-linux: target $(SRCS)
-	GOOS=linux go build -ldflags "-X github.com/solo-io/kubesquash/pkg/cmd.ImageVersion=$(VERSION) -X github.com/solo-io/kubesquash/pkg/cmd.ImageRepo=$(DOCKER_REPO)" -o $@ ./cmd/kubesquash
+	GOOS=linux go build ${LDFLAGS} -o $@ ./cmd/kubesquash
 
 target/kubesquash-container/:
 	[ -d $@ ] || mkdir -p $@

--- a/cmd/kubesquash/main.go
+++ b/cmd/kubesquash/main.go
@@ -16,6 +16,8 @@ IMPORTANT:
   * Due to a technical limitation, KubeSquash doesn't support scratch images at the moment (KubeSquash relies on the 'ls' command present in the image).
 `
 
+var KubeSquashVersion string
+
 func main() {
 	var cfg cmd.SquashConfig
 	flag.Usage = func() {
@@ -40,7 +42,14 @@ func main() {
 	flag.StringVar(&cfg.Container, "container", "", "Container to debug")
 	flag.StringVar(&cfg.CRISock, "crisock", "/var/run/dockershim.sock", "The path to the CRI socket")
 
+	version := flag.Bool("version", false, "prints current app version")
+
 	flag.Parse()
+
+	if *version {
+		fmt.Println(KubeSquashVersion)
+		os.Exit(0)
+	}
 
 	err := cmd.StartDebugContainer(cfg)
 	if err != nil {

--- a/cmd/kubesquash/main.go
+++ b/cmd/kubesquash/main.go
@@ -8,10 +8,12 @@ import (
 	"github.com/solo-io/kubesquash/pkg/cmd"
 )
 
-const descriptionUsage = `Normally squash lite requires no arguments. just run it!
-it works by creating additional privileged debug pod and then attaching to it. 
-Kubernetes with CRI is needed. Due to a technical limitation, kubesquash doesn't support 
-scratch images at the moment (squash lite relys on the 'ls' command present in the image). 
+const descriptionUsage = `Normally KubeSquash requires no arguments. Just run it!
+It works by creating additional privileged debug pod and then attaching to it.
+
+IMPORTANT:
+  * Kubernetes with CRI is needed - see https://kubernetes.io/docs/setup/cri/.
+  * Due to a technical limitation, KubeSquash doesn't support scratch images at the moment (KubeSquash relies on the 'ls' command present in the image).
 `
 
 func main() {
@@ -22,10 +24,10 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.BoolVar(&cfg.NoClean, "no-clean", false, "don't clean temporar pod when existing")
+	flag.BoolVar(&cfg.NoClean, "no-clean", false, "don't clean temporary pod when existing")
 	flag.BoolVar(&cfg.ChooseDebugger, "no-guess-debugger", false, "don't auto detect debugger to use")
 	flag.BoolVar(&cfg.ChoosePod, "no-guess-pod", false, "don't auto detect pod to use")
-	flag.BoolVar(&cfg.NoDetectSkaffold, "no-detect-pod", false, "don't auto settigns based on skaffold configuration present in current folder")
+	flag.BoolVar(&cfg.NoDetectSkaffold, "no-detect-pod", false, "don't auto settings based on skaffold configuration present in current folder")
 	flag.BoolVar(&cfg.DebugServer, "debug-server", false, "start a debug server instead of an interactive session")
 	flag.IntVar(&cfg.TimeoutSeconds, "timeout", 300, "timeout in seconds to wait for debug pod to be ready")
 	flag.StringVar(&cfg.DebugContainerVersion, "container-version", cmd.ImageVersion, "debug container version to use")


### PR DESCRIPTION
While playing with `kubesquash` I noticed that there is no simple way to know which version of the cli tool one is using. This PR brings `--version` flag which prints the `$(VERSION)` set by the `Makefile`.

In addition, it sets `LDFLAGS` in one place and re-uses them across the compilation targets.